### PR TITLE
Increase number of parallel curl connections

### DIFF
--- a/libmamba/include/mamba/core/context.hpp
+++ b/libmamba/include/mamba/core/context.hpp
@@ -137,7 +137,7 @@ namespace mamba
         ChannelPriority channel_priority = ChannelPriority::kFlexible;
         bool auto_activate_base = false;
 
-        std::size_t download_threads = 5;
+        std::size_t download_threads = 50;
         int extract_threads = 0;
 
         int verbosity = 0;


### PR DESCRIPTION
`download_threads` sets `CURLMOPT_MAX_TOTAL_CONNECTIONS` which defaults to 50 in the `curl --parallel` CLI.